### PR TITLE
infra: npm workspaces monorepo scaffold

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "git-extract-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "quasar dev",
+    "build": "quasar build",
+    "lint": "eslint --ext .js,.vue src/"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "git-extract",
+  "version": "0.1.0",
+  "private": true,
+  "workspaces": [
+    "frontend",
+    "worker"
+  ],
+  "scripts": {
+    "dev:frontend": "npm -w frontend run dev",
+    "dev:worker": "npm -w worker run dev",
+    "build": "npm -w frontend run build && npm -w worker run build",
+    "lint": "npm -w frontend run lint && npm -w worker run lint"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "git-extract-worker",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "wrangler dev",
+    "build": "wrangler deploy --dry-run",
+    "deploy": "wrangler deploy",
+    "lint": "eslint --ext .js src/"
+  }
+}


### PR DESCRIPTION
Closes #3

## What

Sets up the npm workspaces monorepo so `frontend/` and `worker/` are managed from a single root `npm install`.

## Files

**`package.json`** (root)
- `workspaces: ["frontend", "worker"]`
- Top-level scripts: `dev:frontend`, `dev:worker`, `build`, `lint` — each delegates to the matching workspace
- `engines.node >= 18`

**`frontend/package.json`** — stub declaring `quasar dev / build / lint` scripts (real deps added in #4)

**`worker/package.json`** — stub declaring `wrangler dev / deploy / lint` scripts (real deps added in #5)

## Test plan
- `npm install` from root resolves both workspaces without error
- `npm run dev:frontend` and `npm run dev:worker` delegate correctly (will fail until deps are installed in #4/#5 — that is expected)