### PR TITLE
frontend: implement GitLab PKCE OAuth flow

### DIFF
--- a/frontend/src/services/gitlab.js
+++ b/frontend/src/services/gitlab.js
@@ -1,0 +1,60 @@
+const VERIFIER_KEY = 'gitlab_verifier';
+const HOST_KEY = 'gitlab_host';
+
+async function generateCodeChallenge(verifier) {
+  const encoded = new TextEncoder().encode(verifier);
+  const digest = await crypto.subtle.digest('SHA-256', encoded);
+  return btoa(String.fromCharCode(...new Uint8Array(digest)))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+export async function startGitlabLogin(host, clientId) {
+  const bytes = crypto.getRandomValues(new Uint8Array(48));
+  const verifier = Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+
+  const challenge = await generateCodeChallenge(verifier);
+
+  sessionStorage.setItem(VERIFIER_KEY, verifier);
+  sessionStorage.setItem(HOST_KEY, host);
+
+  const redirectUri = `${window.location.origin}/#/auth/gitlab`;
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    response_type: 'code',
+    scope: 'read_api',
+    code_challenge: challenge,
+    code_challenge_method: 'S256',
+  });
+
+  window.location.href = `https://${host}/oauth/authorize?${params}`;
+}
+
+export async function exchangeGitlabCode(code) {
+  const verifier = sessionStorage.getItem(VERIFIER_KEY);
+  const host = sessionStorage.getItem(HOST_KEY);
+
+  sessionStorage.removeItem(VERIFIER_KEY);
+  sessionStorage.removeItem(HOST_KEY);
+
+  const redirectUri = `${window.location.origin}/#/auth/gitlab`;
+  const body = new URLSearchParams({
+    client_id: process.env.GITLAB_CLIENT_ID,
+    code,
+    code_verifier: verifier,
+    grant_type: 'authorization_code',
+    redirect_uri: redirectUri,
+  });
+
+  const response = await fetch(`https://${host}/oauth/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body,
+  });
+
+  return response.json();
+}


### PR DESCRIPTION
## Summary

- Add `frontend/src/services/gitlab.js` with two exported functions:
  - `startGitlabLogin(host, clientId)` — generates a 48-byte hex `code_verifier`, derives `code_challenge` via `crypto.subtle.digest('SHA-256')` + base64url, stores verifier + host in `sessionStorage`, redirects to GitLab authorize endpoint with full PKCE params
  - `exchangeGitlabCode(code)` — reads and removes verifier/host from `sessionStorage`, POSTs `application/x-www-form-urlencoded` to `/oauth/token`, returns parsed JSON response
- Supports both `gitlab.com` and self-hosted GitLab instances

## Test plan

- [ ] `startGitlabLogin('gitlab.com', clientId)` redirects to `https://gitlab.com/oauth/authorize` with `response_type=code`, `scope=read_api`, `code_challenge_method=S256`, correct `redirect_uri`
- [ ] `sessionStorage` keys `gitlab_verifier` and `gitlab_host` are set before redirect
- [ ] `exchangeGitlabCode(code)` POSTs to `https://gitlab.com/oauth/token` with correct body fields
- [ ] `sessionStorage` keys are removed after `exchangeGitlabCode` is called
- [ ] Works with a custom self-hosted GitLab host URL

Closes #7