### PR TITLE
worker: add GitHub OAuth callback route

### DIFF
--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -1,10 +1,13 @@
 import { Router } from 'itty-router';
+import { githubCallback } from './routes/auth.js';
 
 const router = Router();
 
 router.get('/', () => {
   return Response.json({ status: 'ok' });
 });
+
+router.get('/auth/github/callback', githubCallback);
 
 router.all('*', () => new Response('Not Found', { status: 404 }));
 

--- a/worker/src/routes/auth.js
+++ b/worker/src/routes/auth.js
@@ -1,0 +1,27 @@
+export async function githubCallback(request, env) {
+  const url = new URL(request.url);
+  const code = url.searchParams.get('code');
+
+  if (!code) {
+    return Response.redirect(`${env.SPA_URL}/#/login?error=missing_code`, 302);
+  }
+
+  const tokenRes = await fetch('https://github.com/login/oauth/access_token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify({
+      client_id: env.GITHUB_CLIENT_ID,
+      client_secret: env.GITHUB_CLIENT_SECRET,
+      code,
+    }),
+  });
+
+  const data = await tokenRes.json();
+
+  if (data.error || !data.access_token) {
+    const msg = data.error_description || data.error || 'token_exchange_failed';
+    return Response.redirect(`${env.SPA_URL}/#/login?error=${encodeURIComponent(msg)}`, 302);
+  }
+
+  return Response.redirect(`${env.SPA_URL}/#/auth/github?token=${data.access_token}`, 302);
+}


### PR DESCRIPTION
## Summary

- Adds `worker/src/routes/auth.js` with a `githubCallback` handler that implements the GitHub OAuth code-for-token exchange
- On success, redirects the user to `${SPA_URL}/#/auth/github?token=<access_token>`
- On failure (missing code or token exchange error), redirects to `${SPA_URL}/#/login?error=<message>`
- Registers the route `GET /auth/github/callback` in `worker/src/index.js`

## Test plan

- [ ] Deploy worker to a preview environment with `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, and `SPA_URL` set
- [ ] Initiate the OAuth flow from the SPA and verify a successful redirect lands at `/#/auth/github?token=...`
- [ ] Hit `/auth/github/callback` with no `code` param and verify redirect to `/#/login?error=missing_code`
- [ ] Simulate a bad code and verify redirect to `/#/login?error=<github error message>`
- [ ] Confirm `GITHUB_CLIENT_SECRET` never appears in any response body or log

Closes #6