### PR TITLE
frontend: add GitHub and GitLab API service layers

### DIFF
--- a/frontend/src/services/github.js
+++ b/frontend/src/services/github.js
@@ -1,8 +1,26 @@
 const BASE = 'https://api.github.com'
 
-export async function fetchCurrentUser(token) {
-  const res = await fetch(`${BASE}/user`, {
-    headers: { Authorization: `Bearer ${token}`, Accept: 'application/vnd.github+json' },
-  })
+const headers = (token) => ({
+  Authorization: `Bearer ${token}`,
+  Accept: 'application/vnd.github+json',
+})
+
+async function apiFetch(url, token) {
+  const res = await fetch(url, { headers: headers(token) })
+  if (!res.ok) return { error: res.status, message: await res.text() }
   return res.json()
 }
+
+export const getUser = (token) => apiFetch(`${BASE}/user`, token)
+
+export const listRepos = (token, page = 1) =>
+  apiFetch(`${BASE}/user/repos?per_page=50&sort=updated&page=${page}`, token)
+
+export const getBranches = (token, owner, repo) =>
+  apiFetch(`${BASE}/repos/${owner}/${repo}/branches`, token)
+
+export const getTree = (token, owner, repo, sha) =>
+  apiFetch(`${BASE}/repos/${owner}/${repo}/git/trees/${sha}?recursive=1`, token)
+
+// kept for backwards compatibility with auth store
+export const fetchCurrentUser = (token) => getUser(token)

--- a/frontend/src/services/gitlab.js
+++ b/frontend/src/services/gitlab.js
@@ -58,3 +58,25 @@ export async function exchangeGitlabCode(code) {
 
   return response.json();
 }
+
+const apiBase = (host) => `https://${host}/api/v4`
+
+const glHeaders = (token) => ({ Authorization: `Bearer ${token}` })
+
+async function glFetch(url, token) {
+  const res = await fetch(url, { headers: glHeaders(token) })
+  if (!res.ok) return { error: res.status, message: await res.text() }
+  return res.json()
+}
+
+export const getUser = (token, host = 'gitlab.com') =>
+  glFetch(`${apiBase(host)}/user`, token)
+
+export const listProjects = (token, host = 'gitlab.com', page = 1) =>
+  glFetch(`${apiBase(host)}/projects?membership=true&per_page=50&page=${page}`, token)
+
+export const getBranches = (token, host = 'gitlab.com', id) =>
+  glFetch(`${apiBase(host)}/projects/${id}/repository/branches`, token)
+
+export const getTree = (token, host = 'gitlab.com', id, ref) =>
+  glFetch(`${apiBase(host)}/projects/${id}/repository/tree?recursive=true&pagination=none&ref=${ref}`, token)


### PR DESCRIPTION
## Summary
- Extends `frontend/src/services/github.js` with `getUser`, `listRepos`, `getBranches`, `getTree`, and a shared `apiFetch` helper; keeps `fetchCurrentUser` as a backwards-compatible alias
- Extends `frontend/src/services/gitlab.js` with `getUser`, `listProjects`, `getBranches`, `getTree`, and a shared `glFetch` helper; existing PKCE functions are untouched

Closes #9

## Test plan
- [ ] `npm -w frontend run lint` passes with no errors
- [ ] Verify `fetchCurrentUser` still works (auth store compatibility)
- [ ] Manually verify GitHub API calls return expected shapes
- [ ] Manually verify GitLab API calls return expected shapes with custom host