### PR TITLE
worker: add GitHub secret encryption utility

### DIFF
--- a/worker/.eslintrc.cjs
+++ b/worker/.eslintrc.cjs
@@ -1,6 +1,7 @@
 module.exports = {
   env: {
     browser: true,
+    es2021: true,
   },
   extends: ['eslint:recommended'],
   parserOptions: {

--- a/worker/src/services/crypto.js
+++ b/worker/src/services/crypto.js
@@ -1,0 +1,14 @@
+import { box } from 'tweetnacl'
+
+export async function encryptForGitHub(base64PublicKey, secretValue) {
+  const repoKey = Uint8Array.from(atob(base64PublicKey), (c) => c.charCodeAt(0))
+  const ephemeral = box.keyPair()
+  const nonce = crypto.getRandomValues(new Uint8Array(24))
+  const msg = new TextEncoder().encode(secretValue)
+  const sealed = box(msg, nonce, repoKey, ephemeral.secretKey)
+  const out = new Uint8Array(ephemeral.publicKey.length + nonce.length + sealed.length)
+  out.set(ephemeral.publicKey, 0)
+  out.set(nonce, ephemeral.publicKey.length)
+  out.set(sealed, ephemeral.publicKey.length + nonce.length)
+  return btoa(String.fromCharCode(...out))
+}


### PR DESCRIPTION
## Summary

- Add `worker/src/services/crypto.js` with `encryptForGitHub` utility using `tweetnacl`
- Fix ESLint config to include `es2021` environment so typed array globals (`Uint8Array`) are recognized

Closes #13