### PR TITLE
frontend: add StatusPoller component

### DIFF
--- a/frontend/src/components/StatusPoller.vue
+++ b/frontend/src/components/StatusPoller.vue
@@ -1,0 +1,67 @@
+<template>
+  <div>
+    <!-- Running -->
+    <template v-if="!done">
+      <q-linear-progress indeterminate color="primary" class="q-mb-sm" />
+      <div class="text-center text-grey">{{ statusText }}</div>
+    </template>
+
+    <!-- Success -->
+    <q-banner v-else-if="success" rounded class="bg-positive text-white q-mt-md">
+      <template #avatar><q-icon name="check_circle" /></template>
+      Extraction complete!
+      <template v-if="targetRepoUrl">
+        <a :href="targetRepoUrl" target="_blank" class="text-white q-ml-sm">View target repo →</a>
+      </template>
+    </q-banner>
+
+    <!-- Failure / cancelled -->
+    <q-banner v-else rounded class="bg-negative text-white q-mt-md">
+      <template #avatar><q-icon name="error" /></template>
+      Extraction {{ conclusion }}.
+      <a :href="runUrl" target="_blank" class="text-white q-ml-sm">View logs →</a>
+    </q-banner>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, onUnmounted } from 'vue'
+
+const props = defineProps({
+  runId: { type: String, required: true },
+  runUrl: { type: String, required: true },
+  targetRepoUrl: { type: String, default: '' },
+})
+
+const status = ref('queued')
+const conclusion = ref(null)
+let timer = null
+
+const done = computed(() => status.value === 'completed')
+const success = computed(() => conclusion.value === 'success')
+const statusText = computed(() => {
+  const map = { queued: 'Queued…', in_progress: 'Running…', waiting: 'Waiting…' }
+  return map[status.value] || 'Working…'
+})
+
+async function poll() {
+  try {
+    const res = await fetch(
+      `${process.env.WORKER_URL}/status?runId=${encodeURIComponent(props.runId)}`,
+    )
+    const data = await res.json()
+    status.value = data.status || status.value
+    conclusion.value = data.conclusion || null
+    if (done.value) clearInterval(timer)
+  } catch {
+    // network error — keep polling
+  }
+}
+
+onMounted(() => {
+  poll()
+  timer = setInterval(poll, 5000)
+})
+
+onUnmounted(() => clearInterval(timer))
+</script>

--- a/frontend/src/pages/ExtractPage.vue
+++ b/frontend/src/pages/ExtractPage.vue
@@ -67,9 +67,15 @@
 
       <!-- Post-submit status -->
       <div v-else class="q-mt-lg">
-        <q-banner rounded class="bg-positive text-white">
+        <StatusPoller
+          v-if="runId"
+          :run-id="runId"
+          :run-url="runUrl"
+          :target-repo-url="targetRepoUrl"
+        />
+        <q-banner v-else rounded class="bg-positive text-white">
           <template #avatar><q-icon name="check_circle" /></template>
-          Extraction job submitted successfully.
+          Extraction job submitted.
         </q-banner>
       </div>
     </template>
@@ -89,6 +95,7 @@ import {
   getTree as getGlTree,
 } from '../services/gitlab.js'
 import FolderTree from '../components/FolderTree.vue'
+import StatusPoller from '../components/StatusPoller.vue'
 
 const store = useReposStore()
 const auth = useAuthStore()
@@ -101,10 +108,18 @@ const targetBranches = ref([])
 const treeLoading = ref(false)
 const submitting = ref(false)
 const submitted = ref(false)
+const runId = ref('')
+const runUrl = ref('')
 
 const canSubmit = computed(
   () => !!store.sourcePath && !!store.selectedTarget && !!targetBranch.value,
 )
+
+const targetRepoUrl = computed(() => {
+  if (!store.selectedTarget) return ''
+  const base = auth.provider === 'github' ? 'https://github.com' : `https://${auth.gitlabHost}`
+  return `${base}/${store.selectedTarget.fullName}`
+})
 
 onMounted(async () => {
   if (!source.value) return
@@ -166,7 +181,7 @@ async function submit() {
   const ghBase = 'https://github.com'
   const glBase = `https://${auth.gitlabHost}`
   const base = auth.provider === 'github' ? ghBase : glBase
-  await fetch(`${process.env.WORKER_URL}/extract`, {
+  const res = await fetch(`${process.env.WORKER_URL}/extract`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -179,6 +194,9 @@ async function submit() {
       targetPath: store.targetPath,
     }),
   })
+  const data = await res.json()
+  runId.value = data.runId || ''
+  runUrl.value = data.runUrl || ''
   submitting.value = false
   submitted.value = true
 }


### PR DESCRIPTION
## Summary

- Adds `frontend/src/components/StatusPoller.vue` — polls `GET /status?runId=<id>` every 5 seconds, shows an indeterminate progress bar while the run is in progress, a green success banner (with link to the target repo) on completion, and a red failure/cancelled banner with a link to the run logs
- Updates `ExtractPage.vue` to capture `runId` and `runUrl` from the `/extract` JSON response and render `<StatusPoller>` post-submit; falls back to a plain banner if the worker returns no `runId`

## Test plan

- [ ] Submit an extraction and verify the progress bar appears immediately
- [ ] Wait for the Actions run to complete and confirm the success banner shows with the target-repo link
- [ ] Test with a failing/cancelled run and confirm the failure banner links to the run logs
- [ ] Unmount the page mid-poll and verify no further network requests are made (interval cleaned up)

Closes #16