### PR TITLE
worker: centralize CORS and add global error handler

### DIFF
--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -1,18 +1,37 @@
-import { Router } from 'itty-router';
-import { githubCallback } from './routes/auth.js';
-import { handleExtract } from './routes/extract.js';
-import { handleStatus } from './routes/status.js';
+import { Router } from 'itty-router'
+import { githubCallback } from './routes/auth.js'
+import { handleExtract } from './routes/extract.js'
+import { handleStatus } from './routes/status.js'
 
-const router = Router();
+const router = Router()
 
-router.get('/', () => Response.json({ status: 'ok' }));
-router.get('/auth/github/callback', githubCallback);
-router.post('/extract', handleExtract);
-router.options('/extract', handleExtract);
-router.get('/status', handleStatus);
-router.options('/status', handleStatus);
-router.all('*', () => new Response('Not Found', { status: 404 }));
+router.get('/auth/github/callback', githubCallback)
+router.post('/extract', handleExtract)
+router.get('/status', handleStatus)
+router.options('*', () => new Response(null, { status: 204 }))
+router.all('*', () => Response.json({ error: 'not found' }, { status: 404 }))
+
+function withCors(response, request, env) {
+  const origin = request.headers.get('Origin')
+  if (!origin || origin !== env.SPA_URL) return response
+  const headers = new Headers(response.headers)
+  headers.set('Access-Control-Allow-Origin', env.SPA_URL)
+  headers.set('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
+  headers.set('Access-Control-Allow-Headers', 'Content-Type')
+  return new Response(response.body, { status: response.status, statusText: response.statusText, headers })
+}
 
 export default {
-  fetch: (request, env, ctx) => router.fetch(request, env, ctx),
-};
+  async fetch(request, env, ctx) {
+    try {
+      const response = await router.fetch(request, env, ctx)
+      return withCors(response, request, env)
+    } catch (err) {
+      return withCors(
+        Response.json({ error: 'internal error' }, { status: 500 }),
+        request,
+        env,
+      )
+    }
+  },
+}

--- a/worker/src/routes/extract.js
+++ b/worker/src/routes/extract.js
@@ -2,31 +2,19 @@ import { orchestrate } from '../services/actionsOrchestrator.js'
 
 const REQUIRED = ['sourceRepoUrl', 'sourceToken', 'sourcePath', 'targetRepoUrl', 'targetToken', 'targetBranch', 'targetPath']
 
-function corsHeaders(env) {
-  return {
-    'Access-Control-Allow-Origin': env.SPA_URL,
-    'Access-Control-Allow-Methods': 'POST, OPTIONS',
-    'Access-Control-Allow-Headers': 'Content-Type',
-  }
-}
-
 export async function handleExtract(request, env, ctx) {
-  if (request.method === 'OPTIONS') {
-    return new Response(null, { status: 204, headers: corsHeaders(env) })
-  }
-
   let body
   try {
     body = await request.json()
   } catch {
-    return Response.json({ error: 'Invalid JSON body' }, { status: 400, headers: corsHeaders(env) })
+    return Response.json({ error: 'Invalid JSON body' }, { status: 400 })
   }
 
   const missing = REQUIRED.filter((k) => !body[k])
   if (missing.length) {
     return Response.json(
       { error: `Missing required fields: ${missing.join(', ')}` },
-      { status: 400, headers: corsHeaders(env) },
+      { status: 400 },
     )
   }
 
@@ -35,5 +23,5 @@ export async function handleExtract(request, env, ctx) {
 
   ctx.waitUntil(orchestrate({ ...body, runId }, env).catch(() => {}))
 
-  return Response.json({ runId, runUrl }, { headers: corsHeaders(env) })
+  return Response.json({ runId, runUrl })
 }

--- a/worker/src/routes/status.js
+++ b/worker/src/routes/status.js
@@ -1,23 +1,11 @@
 const GH_API = 'https://api.github.com'
 
-function corsHeaders(env) {
-  return {
-    'Access-Control-Allow-Origin': env.SPA_URL,
-    'Access-Control-Allow-Methods': 'GET, OPTIONS',
-    'Access-Control-Allow-Headers': 'Content-Type',
-  }
-}
-
 export async function handleStatus(request, env) {
-  if (request.method === 'OPTIONS') {
-    return new Response(null, { status: 204, headers: corsHeaders(env) })
-  }
-
   const url = new URL(request.url)
   const runId = url.searchParams.get('runId')
 
   if (!runId) {
-    return Response.json({ error: 'Missing runId query parameter' }, { status: 400, headers: corsHeaders(env) })
+    return Response.json({ error: 'Missing runId query parameter' }, { status: 400 })
   }
 
   const res = await fetch(
@@ -32,12 +20,11 @@ export async function handleStatus(request, env) {
   )
 
   if (!res.ok) {
-    return Response.json({ error: 'Run not found' }, { status: res.status, headers: corsHeaders(env) })
+    return Response.json({ error: 'Run not found' }, { status: res.status })
   }
 
   const run = await res.json()
   return Response.json(
     { status: run.status, conclusion: run.conclusion, runUrl: run.html_url },
-    { headers: corsHeaders(env) },
   )
 }


### PR DESCRIPTION
## Summary

- Centralize CORS handling in `worker/src/index.js` via a `withCors` wrapper that runs after every route and on errors, instead of duplicating CORS headers in each route handler
- Remove the `corsHeaders` helper and per-response `headers: corsHeaders(env)` calls from `extract.js` and `status.js`
- Remove per-route `OPTIONS` handling from both route files; a single global `router.options('*')` handler now covers all preflight requests
- Add global error handling: uncaught errors return `{ error: 'internal error' }` with status 500, also wrapped with CORS

Closes #18