### PR TITLE
fix: initialize Pinia and load Font Awesome icons

### DIFF
--- a/frontend/quasar.config.js
+++ b/frontend/quasar.config.js
@@ -9,16 +9,16 @@ module.exports = configure(function (/* ctx */) {
       errors: true,
     },
 
-    boot: [],
+    boot: ['pinia'],
 
     css: ['app.scss'],
 
-    extras: ['roboto-font', 'material-icons'],
+    extras: ['roboto-font', 'material-icons', 'fontawesome-v6'],
 
     build: {
       target: {
         browser: ['es2019', 'edge88', 'firefox78', 'chrome87', 'safari13.1'],
-        node: 'node20',
+        node: 'node24',
       },
 
       vueRouterMode: 'hash',

--- a/frontend/src/boot/pinia.js
+++ b/frontend/src/boot/pinia.js
@@ -1,0 +1,6 @@
+import { boot } from 'quasar/wrappers'
+import { createPinia } from 'pinia'
+
+export default boot(({ app }) => {
+  app.use(createPinia())
+})


### PR DESCRIPTION
## Problem

The app threw errors immediately on load and rendered nothing useful in the browser.

## Root causes fixed

### 1. Missing Pinia boot file (critical)
`boot: []` in `quasar.config.js` meant `app.use(pinia)` was never called. Every store access (`useAuthStore`, `useReposStore`) threw:
```
[🍍] "getActivePinia()" was called but there was no active Pinia.
```
**Fix:** Added `frontend/src/boot/pinia.js` that calls `app.use(createPinia())`, registered it in the `boot` array.

### 2. Font Awesome not bundled
`LoginPage.vue` renders GitHub and GitLab buttons with `icon="fab fa-github"` / `icon="fab fa-gitlab"`, but `fontawesome-v6` was absent from `quasar.config.js` extras — icons rendered as blank boxes.
**Fix:** Added `'fontawesome-v6'` to the `extras` array.

### 3. Stale node build target
`node: 'node20'` was left behind after the engine constraint was bumped to `>=24`.
**Fix:** Updated to `node: 'node24'`.

## Test plan
- [x] `npm -w frontend run lint` passes
- [x] `npm -w frontend run build` succeeds
- [ ] Open the app — login page renders with GitHub/GitLab buttons and icons visible
- [ ] Clicking login redirects correctly (no Pinia console errors)